### PR TITLE
Create blank userprofile

### DIFF
--- a/djcloudbridge/view_helpers.py
+++ b/djcloudbridge/view_helpers.py
@@ -188,6 +188,11 @@ def get_credentials_by_id(cloud, request, credentials_id):
     """
     if request.user.is_anonymous:
         return {}
+
+    if not hasattr(request.user, 'userprofile'):
+        # Create a user profile if it does not exist
+        models.UserProfile.objects.create(user=request.user)
+
     profile = request.user.userprofile
 
     if credentials_id:
@@ -211,6 +216,11 @@ def get_credentials_from_profile(cloud, request):
     """
     if request.user.is_anonymous:
         return {}
+
+    if not hasattr(request.user, 'userprofile'):
+        # Create a user profile if it does not exist
+        models.UserProfile.objects.create(user=request.user)
+
     profile = request.user.userprofile
 
     # Check for default credentials


### PR DESCRIPTION
This is intended to fix the recurrent "No userprofile" Sentry bug (Sentry is down atm but will add bug # here later) by creating a blank user profile if one does not exist whenever it is accessed.