### PR TITLE
django-rest-polymorphic pinned to 0.1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 REQS_BASE = [
     'django-polymorphic>=2.0.3',  # for polymorphic model support
-    'django-rest-polymorphic>=0.1.8',  # drf plugin for polymorphic models
+    'django-rest-polymorphic==0.1.8',  # drf plugin for polymorphic models, 0.1.9 came out in April 2020 and breaks CL
     'django-nested-admin>=3.0.21',  # for nested object editing in django admin
     'djangorestframework>=3.0.0',
     'drf-nested-routers',


### PR DESCRIPTION
Attempting to fix bug appearing when authenticating temporary credentials in CL
```
ERROR:django.request:Internal Server Error: /cloudlaunch/api/v1/infrastructure/clouds/aws/authenticate/
Traceback (most recent call last):
File "/app/venv/lib/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
response = get_response(request)
File "/app/venv/lib/python3.6/site-packages/django/core/handlers/base.py", line 115, in _get_response
response = self.process_exception_by_middleware(e, request)
File "/app/venv/lib/python3.6/site-packages/django/core/handlers/base.py", line 113, in _get_response
response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/app/venv/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
return view_func(*args, **kwargs)
File "/app/venv/lib/python3.6/site-packages/rest_framework/viewsets.py", line 114, in view
return self.dispatch(request, *args, **kwargs)
File "/app/venv/lib/python3.6/site-packages/rest_framework/views.py", line 505, in dispatch
response = self.handle_exception(exc)
File "/app/venv/lib/python3.6/site-packages/rest_framework/views.py", line 465, in handle_exception
self.raise_uncaught_exception(exc)
File "/app/venv/lib/python3.6/site-packages/rest_framework/views.py", line 476, in raise_uncaught_exception
raise exc
File "/app/venv/lib/python3.6/site-packages/rest_framework/views.py", line 502, in dispatch
response = handler(request, *args, **kwargs)
File "/app/venv/lib/python3.6/site-packages/rest_framework/mixins.py", line 18, in create
serializer.is_valid(raise_exception=True)
File "/app/venv/lib/python3.6/site-packages/rest_framework/serializers.py", line 234, in is_valid
self._validated_data = self.run_validation(self.initial_data)
File "/app/venv/lib/python3.6/site-packages/rest_framework/serializers.py", line 433, in run_validation
value = self.to_internal_value(data)
File "/app/venv/lib/python3.6/site-packages/rest_framework/serializers.py", line 490, in to_internal_value
validated_value = field.run_validation(primitive_value)
File "/app/venv/lib/python3.6/site-packages/rest_polymorphic/serializers.py", line 95, in run_validation
resource_type = self._get_resource_type_from_mapping(data)
File "/app/venv/lib/python3.6/site-packages/rest_polymorphic/serializers.py", line 112, in _get_resource_type_from_mapping
return mapping[self.resource_type_field_name]
TypeError: 'type' object is not subscriptable
```