### PR TITLE
Replace the unmaintained django-fernet-fields with djfernet

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ REQS_BASE = [
     'coreapi>=2.2.3',  # Provides REST API schema
     'drf-nested-routers',
     'django-rest-auth',  # for user serialization
-    'django-fernet-fields',  # for encryption of user cloud credentials
+    'djfernet',  # for encryption of user cloud credentials
     'sqlparse',  # For migrations
     'cloudbridge'
 ]


### PR DESCRIPTION
The `django-fernet-fields` is not longer maintained (See: https://github.com/orcasgit/django-fernet-fields/issues/28) and needs to be replaced with a package that is.